### PR TITLE
Remove pre initialization timer

### DIFF
--- a/src/automatic_start.cpp
+++ b/src/automatic_start.cpp
@@ -7,6 +7,7 @@
 #include <mrs_lib/subscriber_handler.h>
 #include <mrs_lib/publisher_handler.h>
 #include <mrs_lib/service_client_handler.h>
+#include <mrs_lib/node.h>
 
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -84,21 +85,17 @@ typedef enum
 
 const char* state_names[3] = {"IDLING", "TAKEOFF", "FINISHED"};
 
-class AutomaticStart : public rclcpp::Node {
+class AutomaticStart : public mrs_lib::Node {
 
 public:
   AutomaticStart(rclcpp::NodeOptions options);
 
 private:
-  rclcpp::Node::SharedPtr  node_;
   rclcpp::Clock::SharedPtr clock_;
 
   rclcpp::CallbackGroup::SharedPtr cbkgrp_subs_;
   rclcpp::CallbackGroup::SharedPtr cbkgrp_ss_;
   rclcpp::CallbackGroup::SharedPtr cbkgrp_sc_;
-
-  rclcpp::TimerBase::SharedPtr timer_preinitialization_;
-  void                         timerPreInitialization();
 
   void initialize();
 
@@ -229,30 +226,18 @@ private:
 
 /* AutomaticStart::AutomaticStart() //{ */
 
-AutomaticStart::AutomaticStart(rclcpp::NodeOptions options) : Node("automatic_start", options) {
-
-  timer_preinitialization_ = create_wall_timer(std::chrono::duration<double>(1.0), std::bind(&AutomaticStart::timerPreInitialization, this));
+AutomaticStart::AutomaticStart(rclcpp::NodeOptions options)
+    : Node("automatic_start", options)
+    , clock_(this_node().get_clock())
+    , cbkgrp_subs_(this_node().create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
+    , cbkgrp_ss_(this_node().create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
+    , cbkgrp_sc_(this_node().create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
+{
+    this->initialize();
 }
 
 //}
 
-/* timerPreInitialization() //{ */
-
-void AutomaticStart::timerPreInitialization() {
-
-  node_  = this->shared_from_this();
-  clock_ = node_->get_clock();
-
-  cbkgrp_subs_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_ss_   = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_sc_   = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
-  initialize();
-
-  timer_preinitialization_->cancel();
-}
-
-//}
 //
 
 /* onInit() //{ */
@@ -265,7 +250,7 @@ void AutomaticStart::initialize() {
   offboard_      = false;
   offboard_time_ = rclcpp::Time(0, 0, clock_->get_clock_type());
 
-  mrs_lib::ParamLoader param_loader(node_, "AutomaticStart");
+  mrs_lib::ParamLoader param_loader(this_node_ptr(), "AutomaticStart");
 
   std::string custom_config_path;
 
@@ -306,7 +291,7 @@ void AutomaticStart::initialize() {
   param_loader.loadParam("preflight_check/topic_check/topics", _topic_check_topic_names_);
 
   if (!param_loader.loadedSuccessfully()) {
-    RCLCPP_ERROR(node_->get_logger(), "[AutomaticStart]: Could not load all parameters!");
+    RCLCPP_ERROR(this_node().get_logger(), "[AutomaticStart]: Could not load all parameters!");
     rclcpp::shutdown();
     exit(1);
   }
@@ -314,7 +299,7 @@ void AutomaticStart::initialize() {
   // | ----------------------- subscribers ---------------------- |
 
   mrs_lib::SubscriberHandlerOptions shopts;
-  shopts.node               = node_;
+  shopts.node               = this_node_ptr();
   shopts.no_message_timeout = mrs_lib::no_timeout;
   shopts.threadsafe         = true;
   shopts.autostart          = true;
@@ -330,15 +315,16 @@ void AutomaticStart::initialize() {
 
   // | ----------------------- publishers ----------------------- |
 
-  ph_can_takeoff_ = mrs_lib::PublisherHandler<std_msgs::msg::Bool>(node_, "~/can_takeoff_out");
+  ph_can_takeoff_ = mrs_lib::PublisherHandler<std_msgs::msg::Bool>(this_node_ptr(), "~/can_takeoff_out");
 
   // | --------------------- service clients -------------------- |
 
-  service_client_takeoff_               = mrs_lib::ServiceClientHandler<std_srvs::srv::Trigger>(node_, "~/takeoff_out");
-  service_client_toggle_control_output_ = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node_, "~/toggle_control_output_out");
-  service_client_arm_                   = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node_, "~/arm_out");
+  rclcpp::Node::SharedPtr node = this_node_ptr();
+  service_client_takeoff_               = mrs_lib::ServiceClientHandler<std_srvs::srv::Trigger>(node, "~/takeoff_out");
+  service_client_toggle_control_output_ = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node, "~/toggle_control_output_out");
+  service_client_arm_                   = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node, "~/arm_out");
 
-  service_client_validate_reference_ = mrs_lib::ServiceClientHandler<mrs_msgs::srv::ValidateReference>(node_, "~/validate_reference_out");
+  service_client_validate_reference_ = mrs_lib::ServiceClientHandler<mrs_msgs::srv::ValidateReference>(node, "~/validate_reference_out");
 
   // | ------------------ setup generic topics ------------------ |
 
@@ -355,14 +341,14 @@ void AutomaticStart::initialize() {
         topic_name = "/" + _uav_name_ + "/" + topic_name;
       }
 
-      Topic tmp_topic(node_, topic_name);
+      Topic tmp_topic(this_node_ptr(), topic_name);
       topic_check_topics_.push_back(tmp_topic);
 
       int id = i;  // id to identify which topic called the generic callback
 
       std::function<void(std::shared_ptr<rclcpp::SerializedMessage> msg)> callback_fcn = std::bind(&AutomaticStart::genericCallback, this, std::placeholders::_1, topic_name, id);
 
-      auto tmp_subscriber = node_->create_generic_subscription(topic_name, topic_type, rclcpp::SystemDefaultsQoS(), callback_fcn);
+      auto tmp_subscriber = this_node().create_generic_subscription(topic_name, topic_type, rclcpp::SystemDefaultsQoS(), callback_fcn);
 
       generic_subscriber_vec_.push_back(tmp_subscriber);
     }
@@ -372,7 +358,7 @@ void AutomaticStart::initialize() {
 
   mrs_lib::TimerHandlerOptions timer_opts_start;
 
-  timer_opts_start.node      = node_;
+  timer_opts_start.node      = this_node_ptr();
   timer_opts_start.autostart = true;
 
   {
@@ -385,7 +371,7 @@ void AutomaticStart::initialize() {
 
   is_initialized_ = true;
 
-  RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: initialized");
+  RCLCPP_INFO_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: initialized");
 }
 
 //}
@@ -411,7 +397,7 @@ void AutomaticStart::callbackHwApiStatus(const mrs_msgs::msg::HwApiStatus::Const
     return;
   }
 
-  RCLCPP_INFO_ONCE(node_->get_logger(), "[AutomaticStart]: getting HW API status");
+  RCLCPP_INFO_ONCE(this_node().get_logger(), "[AutomaticStart]: getting HW API status");
 
   std::scoped_lock lock(mutex_hw_api_status_);
 
@@ -470,7 +456,7 @@ void AutomaticStart::callbackHwApiCapabilities([[maybe_unused]] const mrs_msgs::
     return;
   }
 
-  RCLCPP_INFO_ONCE(node_->get_logger(), "[AutomaticStart]: getting HW API capabilities");
+  RCLCPP_INFO_ONCE(this_node().get_logger(), "[AutomaticStart]: getting HW API capabilities");
 }
 
 //}
@@ -483,7 +469,7 @@ void AutomaticStart::callbackGazeboSpawnerDiagnostics(const mrs_msgs::msg::Gazeb
     return;
   }
 
-  RCLCPP_INFO_ONCE(node_->get_logger(), "[AutomaticStart]: getting spawner diagnostics");
+  RCLCPP_INFO_ONCE(this_node().get_logger(), "[AutomaticStart]: getting spawner diagnostics");
 
   {
     std::scoped_lock lock(mutex_gazebo_spawner_diagnostics_);
@@ -514,7 +500,7 @@ void AutomaticStart::timerMain() {
   bool got_hw_api               = sh_hw_api_status_.hasMsg() && sh_hw_api_capabilities_.hasMsg() && hw_api_connected_;
 
   if (!got_control_manager_diag || !got_hw_api || !got_uav_manager_diag || !got_estimation_diag) {
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 5000, "[AutomaticStart]: waiting for data: ControlManager=%s, UavManager=%s, HW Api=%s, EstimationManager=%s", got_control_manager_diag ? "true" : "FALSE", got_uav_manager_diag ? "true" : "FALSE", got_hw_api ? "true" : "FALSE", got_estimation_diag ? "true" : "FALSE");
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 5000, "[AutomaticStart]: waiting for data: ControlManager=%s, UavManager=%s, HW Api=%s, EstimationManager=%s", got_control_manager_diag ? "true" : "FALSE", got_uav_manager_diag ? "true" : "FALSE", got_hw_api ? "true" : "FALSE", got_estimation_diag ? "true" : "FALSE");
     return;
   }
 
@@ -535,18 +521,18 @@ void AutomaticStart::timerMain() {
 
       if (!offboard && possibly_in_the_air) {
 
-        RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: preflight check failed, the UAV is possibly in the air");
+        RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: preflight check failed, the UAV is possibly in the air");
 
         if (armed) {
 
-          RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: -- the UAV is also armed!! finishing to prevent unwanted system activation");
+          RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: -- the UAV is also armed!! finishing to prevent unwanted system activation");
 
           if (we_toggled_output_) {
 
             bool res = toggleControlOutput(false);
 
             if (!res) {
-              RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output OFF");
+              RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output OFF");
             }
           }
 
@@ -584,7 +570,7 @@ void AutomaticStart::timerMain() {
           bool res = toggleControlOutput(true);
 
           if (!res) {
-            RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output ON");
+            RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output ON");
           } else {
             we_toggled_output_ = true;
           }
@@ -594,7 +580,7 @@ void AutomaticStart::timerMain() {
 
         if (armed_time.seconds() > 0 && time_from_arming > _control_output_timeout_) {
 
-          RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output ON for %.2f secs, disarming", _control_output_timeout_);
+          RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: could not set control output ON for %.2f secs, disarming", _control_output_timeout_);
           disarm();
           changeState(STATE_FINISHED);
         }
@@ -607,13 +593,13 @@ void AutomaticStart::timerMain() {
         if (got_gazebo_spawner_diagnostics) {
 
           if (!gazebo_spawner_diagnostics_.spawn_called || gazebo_spawner_diagnostics_.processing) {
-            RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: (simulation) waiting for spawner to finish spawning UAVs");
+            RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: (simulation) waiting for spawner to finish spawning UAVs");
             return;
           }
 
         } else {
 
-          RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: (simulation) missing spawner diagnostics");
+          RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: (simulation) missing spawner diagnostics");
           return;
         }
       }
@@ -636,7 +622,7 @@ void AutomaticStart::timerMain() {
 
             double min = (armed_time_diff < offboard_time_diff) ? armed_time_diff.seconds() : offboard_time_diff.seconds();
 
-            RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "taking off in %.0f", (_safety_timeout_ - min));
+            RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "taking off in %.0f", (_safety_timeout_ - min));
           }
         }
       }
@@ -649,13 +635,13 @@ void AutomaticStart::timerMain() {
       // if takeoff finished
       if (control_manager_diagnostics->flying_normally) {
 
-        RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: takeoff finished");
+        RCLCPP_INFO_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: takeoff finished");
 
         changeState(STATE_FINISHED);
 
       } else {
 
-        RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: waiting for the takeoff to finish");
+        RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: waiting for the takeoff to finish");
       }
 
       break;
@@ -663,7 +649,7 @@ void AutomaticStart::timerMain() {
 
     case STATE_FINISHED: {
 
-      RCLCPP_INFO_ONCE(node_->get_logger(), "[AutomaticStart]: finished");
+      RCLCPP_INFO_ONCE(this_node().get_logger(), "[AutomaticStart]: finished");
 
       timer_main_->stop();
 
@@ -682,7 +668,7 @@ void AutomaticStart::timerMain() {
 
 void AutomaticStart::changeState(LandingStates_t new_state) {
 
-  RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: switching states %s -> %s", state_names[current_state], state_names[new_state]);
+  RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: switching states %s -> %s", state_names[current_state], state_names[new_state]);
 
   switch (new_state) {
 
@@ -694,7 +680,7 @@ void AutomaticStart::changeState(LandingStates_t new_state) {
     case STATE_TAKEOFF: {
 
       if (_pre_takeoff_sleep_ > 1.0) {
-        RCLCPP_INFO(node_->get_logger(), "[AutomaticStart]: sleeping for %.2f secs before takeoff", _pre_takeoff_sleep_);
+        RCLCPP_INFO(this_node().get_logger(), "[AutomaticStart]: sleeping for %.2f secs before takeoff", _pre_takeoff_sleep_);
         clock_->sleep_for(std::chrono::duration<double>(_pre_takeoff_sleep_));
       }
 
@@ -727,7 +713,7 @@ void AutomaticStart::changeState(LandingStates_t new_state) {
 
 bool AutomaticStart::takeoff() {
 
-  RCLCPP_INFO(node_->get_logger(), "[AutomaticStart]: taking off");
+  RCLCPP_INFO(this_node().get_logger(), "[AutomaticStart]: taking off");
 
   std::shared_ptr<std_srvs::srv::Trigger::Request> request = std::make_shared<std_srvs::srv::Trigger::Request>();
 
@@ -741,12 +727,12 @@ bool AutomaticStart::takeoff() {
 
     } else {
 
-      RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: taking off failed: %s", response.value()->message.c_str());
+      RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: taking off failed: %s", response.value()->message.c_str());
     }
 
   } else {
 
-    RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: service call for taking off failed");
+    RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: service call for taking off failed");
   }
 
   return false;
@@ -768,18 +754,18 @@ bool AutomaticStart::validateReference() {
 
     if (response.value()->success) {
 
-      RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: current position is valid");
+      RCLCPP_INFO_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: current position is valid");
       return true;
 
     } else {
 
-      RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: current position is not valid (safety area, bumper)!");
+      RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: current position is not valid (safety area, bumper)!");
       return false;
     }
 
   } else {
 
-    RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: current position could not be validated");
+    RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: current position could not be validated");
     return false;
   }
 }
@@ -790,7 +776,7 @@ bool AutomaticStart::validateReference() {
 
 bool AutomaticStart::toggleControlOutput(const bool& value) {
 
-  RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: setting control output %s", value ? "ON" : "OFF");
+  RCLCPP_INFO_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: setting control output %s", value ? "ON" : "OFF");
 
   std::shared_ptr<std_srvs::srv::SetBool::Request> request = std::make_shared<std_srvs::srv::SetBool::Request>();
 
@@ -806,12 +792,12 @@ bool AutomaticStart::toggleControlOutput(const bool& value) {
 
     } else {
 
-      RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: setting of control output failed: %s", response.value()->message.c_str());
+      RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: setting of control output failed: %s", response.value()->message.c_str());
     }
 
   } else {
 
-    RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: service call for toggling control output failed");
+    RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: service call for toggling control output failed");
   }
 
   return false;
@@ -825,7 +811,7 @@ bool AutomaticStart::disarm() {
 
   if (!hw_api_connected_) {
 
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: cannot disarm, missing HW API status!");
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: cannot disarm, missing HW API status!");
 
     return false;
   }
@@ -834,12 +820,12 @@ bool AutomaticStart::disarm() {
 
   if (offboard) {
 
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: cannot disarm, already in offboard mode!");
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: cannot disarm, already in offboard mode!");
 
     return false;
   }
 
-  RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: disarming");
+  RCLCPP_INFO_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: disarming");
 
   std::shared_ptr<std_srvs::srv::SetBool::Request> request = std::make_shared<std_srvs::srv::SetBool::Request>();
 
@@ -855,12 +841,12 @@ bool AutomaticStart::disarm() {
 
     } else {
 
-      RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: disarming failed");
+      RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: disarming failed");
     }
 
   } else {
 
-    RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: service call for disarming failed");
+    RCLCPP_ERROR_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: service call for disarming failed");
   }
 
   return false;
@@ -876,11 +862,11 @@ bool AutomaticStart::isGazeboSimulation(void) {
     return true;
   }
 
-  auto node_names = node_->get_node_names();
+  auto node_names = this_node().get_node_names();
 
   for (auto& node : node_names) {
     if (node.find("mrs_drone_spawner") != std::string::npos) {
-      RCLCPP_INFO(node_->get_logger(), "[AutomaticStart]: MRS Gazebo Simulation detected");
+      RCLCPP_INFO(this_node().get_logger(), "[AutomaticStart]: MRS Gazebo Simulation detected");
       is_gazebo_simulation_ = true;
       return true;
     }
@@ -912,7 +898,7 @@ bool AutomaticStart::topicCheck(void) {
   }
 
   if (!got_topics) {
-    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: missing data on topics: " << missing_topics.str());
+    RCLCPP_WARN_STREAM_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: missing data on topics: " << missing_topics.str());
   }
 
   return got_topics;
@@ -940,7 +926,7 @@ bool AutomaticStart::preflightCheckSpeed(void) {
 
   if (speed > _speed_check_max_speed_) {
     speed_check_violated_time_ = clock_->now();
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: the estimated speed (%.2f ms^-2) is over the limit (%.2f ms^-2)", speed, _speed_check_max_speed_);
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: the estimated speed (%.2f ms^-2) is over the limit (%.2f ms^-2)", speed, _speed_check_max_speed_);
   }
 
   if (speed_check_violated_time_.seconds() > 0 && (clock_->now() - speed_check_violated_time_).seconds() < _preflight_check_time_window_) {
@@ -982,7 +968,7 @@ bool AutomaticStart::preflighCheckHeight(void) {
 
   if (height > _height_check_max_height_) {
     height_check_violated_time_ = clock_->now();
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: the height (%.2f m) is over the limit (%.2f m)", height, _height_check_max_height_);
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: the height (%.2f m) is over the limit (%.2f m)", height, _height_check_max_height_);
   }
 
   if (height_check_violated_time_.seconds() > 0 && (clock_->now() - height_check_violated_time_).seconds() < _preflight_check_time_window_) {
@@ -1024,7 +1010,7 @@ bool AutomaticStart::preflighCheckGyro(void) {
 
   if (abs(gyros.x) > _gyro_check_max_rate_ || abs(gyros.y) > _gyro_check_max_rate_ || abs(gyros.z) > _gyro_check_max_rate_) {
     gyro_check_violated_time_ = clock_->now();
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[AutomaticStart]: the angular velocity ([%.2f, %.2f, %.2f] rad/s) is over the limit (%.2f rad/s)", gyros.x, gyros.y, gyros.z, _gyro_check_max_rate_);
+    RCLCPP_WARN_THROTTLE(this_node().get_logger(), *clock_, 1000, "[AutomaticStart]: the angular velocity ([%.2f, %.2f, %.2f] rad/s) is over the limit (%.2f rad/s)", gyros.x, gyros.y, gyros.z, _gyro_check_max_rate_);
   }
 
   if (gyro_check_violated_time_.seconds() > 0 && (clock_->now() - gyro_check_violated_time_).seconds() < _preflight_check_time_window_) {


### PR DESCRIPTION
This PR removes the pre initialization timer workaround. This is possible by using a utility class (added in https://github.com/ctu-mrs/mrs_lib/pull/65) that allows obtaining the `rclcpp::Node::SharedPtr` in the constructor of `AutomaticStart`.