### PR TITLE
Update CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28)
 project(mrs_uav_autostart)
 
 # set the correct standards
@@ -16,7 +16,7 @@ endif()
 
 # set the compile options to show code warnings
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options("-Wall" "-Wextra" "-Wpedantic")
 endif()
 
 if(ENABLE_COVERAGE)
@@ -38,22 +38,15 @@ set(DEPENDENCIES
   std_srvs
   mrs_uav_testing
   backward_ros
-  )
-
-set(LIBRARIES
-  MrsUavAutostart_AutomaticStart
-  )
+)
 
 foreach(DEP IN LISTS DEPENDENCIES)
   find_package(${DEP} REQUIRED)
 endforeach()
 
-include_directories(
-  include
-  ${rclcpp_INCLUDE_DIRS}
-  ${mrs_lib_INCLUDE_DIRS}
-  ${mrs_uav_testing_INCLUDE_DIRS}
-  )
+set(LIBRARIES
+  MrsUavAutostart_AutomaticStart
+)
 
 ## --------------------------------------------------------------
 ## |                           Compile                          |
@@ -63,13 +56,21 @@ include_directories(
 
 add_library(MrsUavAutostart_AutomaticStart SHARED
   src/automatic_start.cpp
-  )
+)
 
-ament_target_dependencies(MrsUavAutostart_AutomaticStart
-  ${DEPENDENCIES}
-  )
+target_link_libraries(MrsUavAutostart_AutomaticStart
+  PUBLIC
+    rclcpp::rclcpp
+    rclcpp_components::component
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+)
 
-rclcpp_components_register_nodes(MrsUavAutostart_AutomaticStart PLUGIN "mrs_uav_autostart::automatic_start::AutomaticStart" EXECUTABLE MrsUavAutostart_AutomaticStart)
+rclcpp_components_register_nodes(MrsUavAutostart_AutomaticStart
+  "mrs_uav_autostart::automatic_start::AutomaticStart"
+)
 
 target_compile_definitions(MrsUavAutostart_AutomaticStart PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
 
@@ -97,30 +98,30 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  )
+)
 
 install(
   DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
-  )
+)
 
 install(
   DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
-  )
+)
 
 install(
   DIRECTORY scripts
   USE_SOURCE_PERMISSIONS
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 ament_export_targets(
   export_${PROJECT_NAME} HAS_LIBRARY_TARGET
-  )
+)
 
 ament_export_dependencies(
   ${DEPENDENCIES}
-  )
+)
 
 ament_package()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,12 +7,8 @@ function(add_ros_isolated_launch_test path)
   add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
 endfunction()
 
-add_subdirectory(./takeoff_should_succeed)
-
-add_subdirectory(./takeoff_should_fail_while_moving)
-
-add_subdirectory(./takeoff_should_fail_outside_safety_area)
-
-add_subdirectory(./takeoff_trigerred_externally)
-
-add_subdirectory(./takeoff_should_fail_topic_check)
+add_subdirectory(takeoff_should_fail_outside_safety_area)
+add_subdirectory(takeoff_should_fail_topic_check)
+add_subdirectory(takeoff_should_fail_while_moving)
+add_subdirectory(takeoff_should_succeed)
+add_subdirectory(takeoff_trigerred_externally)

--- a/test/takeoff_should_fail_outside_safety_area/CMakeLists.txt
+++ b/test/takeoff_should_fail_outside_safety_area/CMakeLists.txt
@@ -2,19 +2,20 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
+)
 
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  mrs_uav_testing
-  backward_ros
-  )
+target_link_libraries(test_${TEST_NAME}
+  rclcpp::rclcpp
+  mrs_lib::mrs_lib
+  mrs_uav_testing::mrs_uav_testing
+  ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+target_compile_definitions(test_${TEST_NAME} PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
+
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/takeoff_should_fail_topic_check/CMakeLists.txt
+++ b/test/takeoff_should_fail_topic_check/CMakeLists.txt
@@ -1,26 +1,21 @@
 get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
-# 1 == use rclcpp::Timer implementation
-# 0 == use MRS's thread timer implementation
-set(USE_ROS_TIMER 0)
-
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
+)
 
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  mrs_uav_testing
-  backward_ros
-  )
+target_link_libraries(test_${TEST_NAME}
+  rclcpp::rclcpp
+  mrs_lib::mrs_lib
+  mrs_uav_testing::mrs_uav_testing
+  ${mrs_msgs_TARGETS}
+)
 
 target_compile_definitions(test_${TEST_NAME} PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/takeoff_should_fail_while_moving/CMakeLists.txt
+++ b/test/takeoff_should_fail_while_moving/CMakeLists.txt
@@ -1,26 +1,21 @@
 get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
-# 1 == use rclcpp::Timer implementation
-# 0 == use MRS's thread timer implementation
-set(USE_ROS_TIMER 0)
-
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
+)
 
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  mrs_uav_testing
-  backward_ros
-  )
+target_link_libraries(test_${TEST_NAME}
+  rclcpp::rclcpp
+  mrs_lib::mrs_lib
+  mrs_uav_testing::mrs_uav_testing
+  ${mrs_msgs_TARGETS}
+)
 
 target_compile_definitions(test_${TEST_NAME} PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/takeoff_should_succeed/CMakeLists.txt
+++ b/test/takeoff_should_succeed/CMakeLists.txt
@@ -2,19 +2,20 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
+)
 
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  mrs_uav_testing
-  backward_ros
-  )
+target_link_libraries(test_${TEST_NAME}
+  rclcpp::rclcpp
+  mrs_lib::mrs_lib
+  mrs_uav_testing::mrs_uav_testing
+  ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+target_compile_definitions(test_${TEST_NAME} PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
+
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)

--- a/test/takeoff_trigerred_externally/CMakeLists.txt
+++ b/test/takeoff_trigerred_externally/CMakeLists.txt
@@ -2,19 +2,20 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
+)
 
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  mrs_uav_testing
-  backward_ros
-  )
+target_link_libraries(test_${TEST_NAME}
+  rclcpp::rclcpp
+  mrs_lib::mrs_lib
+  mrs_uav_testing::mrs_uav_testing
+  ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+target_compile_definitions(test_${TEST_NAME} PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
+
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)


### PR DESCRIPTION
- increased minimum required version of CMake to 3.28
- removed unnecessary global include_directories
- changed uses of `ament_target_dependencies` to `target_link_libraries`
- unified test configs
  - tests now use the global value of `USE_ROS_TIMER`
- sorted `add_subdirectory` calls alphabetically
- removed wrong parameters to `rclcpp_components_register_nodes`
- enabled pedantic warnings (`-Wpedantic`)