### PR TITLE
fix: remapping errors to shared errors topic/fix tests

### DIFF
--- a/launch/automatic_start.launch.py
+++ b/launch/automatic_start.launch.py
@@ -140,6 +140,7 @@ def generate_launch_description():
                     ("~/toggle_control_output_out", "control_manager/toggle_output"),
                     ("~/arm_out", "hw_api/arming"),
                     ("~/validate_reference_out", "control_manager/validate_reference_2d"),
+                    ("~/errors", "errors"),
                 ],
             )
 

--- a/test/errorgraph_clears_after_startup/test.cpp
+++ b/test/errorgraph_clears_after_startup/test.cpp
@@ -31,13 +31,16 @@ Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
   // Subscribe immediately so we capture the full lifecycle:
   // waiting_for_node errors during startup -> empty errors after startup
-  sub_errors_ = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>("/uav1/automatic_start/errors", 100,
-                                                                             std::bind(&Tester::errorsCallback, this, std::placeholders::_1));
+  sub_errors_ =
+      node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>("/uav1/errors", 100, std::bind(&Tester::errorsCallback, this, std::placeholders::_1));
 }
 
 void Tester::errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
   std::scoped_lock lck(errors_mtx_);
-  last_msg_ = *msg;
+  // Only track messages from AutomaticStart — the shared /errors topic carries messages from all managers
+  if (msg->source_node.node == "AutomaticStart" && msg->source_node.component == "main") {
+    last_msg_ = *msg;
+  }
 }
 
 bool Tester::test(void) {
@@ -71,10 +74,6 @@ bool Tester::test(void) {
     }
 
     const auto &element = last_msg_.value();
-
-    if (element.source_node.node != "AutomaticStart" || element.source_node.component != "main") {
-      continue;
-    }
 
     bool has_waiting_for_node = false;
     for (const auto &error : element.errors) {
@@ -124,10 +123,7 @@ int main(int argc, char *argv[]) {
 
   test_result &= tester.test();
 
-  // Sleep long enough for the Python test harness subscriber to connect
-  // to /test_result before we publish. The errorgraph test completes quickly
-  // (~2s), so we need extra time for peer discovery.
-  tester.sleep(10.0);
+  tester.sleep(2.0);
 
   std::cout << "Test: reporting test results" << std::endl;
 

--- a/test/errorgraph_reports_waiting_for_nodes/test.cpp
+++ b/test/errorgraph_reports_waiting_for_nodes/test.cpp
@@ -32,13 +32,16 @@ Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
   // Subscribe to the errorgraph errors topic immediately, before blocking on getUAVHandler.
   // This ensures we capture errors published during the startup window.
-  sub_errors_ = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>("/uav1/automatic_start/errors", 100,
-                                                                             std::bind(&Tester::errorsCallback, this, std::placeholders::_1));
+  sub_errors_ =
+      node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>("/uav1/errors", 100, std::bind(&Tester::errorsCallback, this, std::placeholders::_1));
 }
 
 void Tester::errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
   std::scoped_lock lck(errors_mtx_);
-  received_errors_.push_back(*msg);
+  // Only track messages from AutomaticStart — the shared /errors topic carries messages from all managers
+  if (msg->source_node.node == "AutomaticStart" && msg->source_node.component == "main") {
+    received_errors_.push_back(*msg);
+  }
 }
 
 bool Tester::test(void) {
@@ -66,11 +69,6 @@ bool Tester::test(void) {
       std::scoped_lock lck(errors_mtx_);
 
       for (const auto &element : received_errors_) {
-
-        // Verify source_node identity
-        if (element.source_node.node != "AutomaticStart" || element.source_node.component != "main") {
-          continue;
-        }
 
         for (const auto &error : element.errors) {
           if (error.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_NODE) {
@@ -125,10 +123,7 @@ int main(int argc, char *argv[]) {
 
   test_result &= tester.test();
 
-  // Sleep long enough for the Python test harness subscriber to connect
-  // to /test_result before we publish. The errorgraph test completes quickly
-  // (~2s), so we need extra time for peer discovery.
-  tester.sleep(10.0);
+  tester.sleep(2.0);
 
   std::cout << "Test: reporting test results" << std::endl;
 


### PR DESCRIPTION
## Summary
- **What changed**: Added remapping of the node errors to the shared/general errors topic
- **Why**: To have a centralized error topic per robot, helping to retrieve errors.
- **Notes for reviewers**:  Fix, updated tests according to this behavior.

## Impact
- **Affected areas**: None
- **Breaking changes**: No

## Testing status
- **What was tested**:
 That there is only one `/uav1/errors` topic in the simulator, specific tests are filtering the errors topic  with the component name "AutomaticStart" 
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [x] Tested on real HW

- **How to repeat tests**:

Then running the tests:
 ```bash
 colcon build --packages-select mrs_uav_autostart --cmake-args -DENABLE_TESTS=1
 ./test/run_specific_test.sh
 ```

